### PR TITLE
simplify recipe for mln/version.hh

### DIFF
--- a/milena/Makefile.am
+++ b/milena/Makefile.am
@@ -105,9 +105,7 @@ edit = sed -e 's,@PACKAGE_BUGREPORT[@],$(PACKAGE_BUGREPORT),g'	\
 EXTRA_DIST = mln/version.hh.in
 $(srcdir)/mln/version.hh: mln/version.hh.in $(top_srcdir)/configure.ac Makefile.am
 	rm -f $@ $@.tmp
-	srcdir=''; \
-	  test -f ./$@.in || srcdir=$(srcdir)/; \
-	  $(edit) $${srcdir}$@.in >$@.tmp
+	$(edit) $@.in >$@.tmp
 	chmod a-w $@.tmp
 	mv $@.tmp $@
 


### PR DESCRIPTION
w/o this, I ran into the situation that the path was duplicated and the file not found.

Also, the recipe for `regen-am` looks fishy (l. 73-76:

```makefile
srcdir=''; \
  test -f ./$(srcdir)/mln/version.hh.in || srcdir=$(srcdir)/; \
  $(edit) $${srcdir}$(srcdir)/mln/version.hh.in \
    >$(srcdir)/mln/version.hh.tmp
```

No idea why I haven't run into this issue before.

